### PR TITLE
[closes #1] Import shim in host app

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,7 +14,5 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  app.import('vendor/shims/css-mediaquery.js');
-
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -2,5 +2,11 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-screen'
+  name: 'ember-screen',
+
+  included: function(app) {
+    this._super.included(app);
+
+    app.import('vendor/shims/css-mediaquery.js');
+  }
 };


### PR DESCRIPTION
We need to import the shim in `index.js` so the host app gets it too.

Fixes #1
