### PR TITLE
Remove Ember@2.x versions from Ember Try matrix that are not run in CI

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,38 +11,6 @@ module.exports = function() {
     return {
       scenarios: [
         {
-          name: 'ember-lts-2.4',
-          bower: {
-            dependencies: {
-              'ember': 'components/ember#lts-2-4'
-            },
-            resolutions: {
-              'ember': 'lts-2-4'
-            }
-          },
-          npm: {
-            devDependencies: {
-              'ember-source': null
-            }
-          }
-        },
-        {
-          name: 'ember-lts-2.8',
-          bower: {
-            dependencies: {
-              'ember': 'components/ember#lts-2-8'
-            },
-            resolutions: {
-              'ember': 'lts-2-8'
-            }
-          },
-          npm: {
-            devDependencies: {
-              'ember-source': null
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.12',
           npm: {
             devDependencies: {


### PR DESCRIPTION
Remove Ember@2.x versions from Ember Try matrix that are not run in CI (see [travis.yml](https://github.com/mitchlloyd/ember-screen/blob/master/.travis.yml)) since these don't provide much value sticking around / could cause some confusion. 